### PR TITLE
Add stock modal for Portfolio Page

### DIFF
--- a/src/components/add-stock-modal/index.tsx
+++ b/src/components/add-stock-modal/index.tsx
@@ -7,15 +7,19 @@ type AddStockModalProps = {
 };
 
 const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
-  console.log(isShowing);
   return (
     <div
-      className={cn("absolute px-4 md:flex md:items-center md:justify-center z-10", {
+      className={cn("fixed px-4 md:flex md:items-center md:justify-center z-10 inset-0", {
         hidden: !isShowing,
         "md:hidden": !isShowing
       })}
     >
-      <div className="bg-black opacity-75 w-full absolute z-10 inset-0" />
+      <div
+        className="bg-black opacity-75 w-full absolute z-10 inset-0"
+        onClick={cancel}
+        onKeyDown={cancel}
+        aria-hidden="true"
+      />
       <div className="bg-white rounded-lg md:max-w-md md:mx-auto p-4 fixed inset-x-0 bottom-0 z-50 mb-4 mx-4 md:relative shadow-lg">
         <div className="md:flex items-center">
           <div className="rounded-full border border-gray-300 flex items-center justify-center w-16 h-16 flex-shrink-0 mx-auto">

--- a/src/components/add-stock-modal/index.tsx
+++ b/src/components/add-stock-modal/index.tsx
@@ -1,0 +1,57 @@
+import { FC } from "react";
+import cn from "classnames";
+
+type AddStockModalProps = {
+  isShowing: boolean;
+  cancel: () => void;
+};
+
+const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
+  console.log(isShowing);
+  return (
+    <div
+      className={cn("absolute px-4 md:flex md:items-center md:justify-center z-10", {
+        hidden: !isShowing,
+        "md:hidden": !isShowing
+      })}
+    >
+      <div className="bg-black opacity-75 w-full absolute z-10 inset-0" />
+      <div className="bg-white rounded-lg md:max-w-md md:mx-auto p-4 fixed inset-x-0 bottom-0 z-50 mb-4 mx-4 md:relative shadow-lg">
+        <div className="md:flex items-center">
+          <div className="rounded-full border border-gray-300 flex items-center justify-center w-16 h-16 flex-shrink-0 mx-auto">
+            <i className="bx bx-error text-3xl" />
+          </div>
+          <div className="mt-4 md:mt-0 md:ml-6 text-center md:text-left">
+            <p className="font-bold">Delete your account</p>
+            <p className="text-sm text-gray-700 mt-1">
+              You will lose all of your data by deleting your account. This action cannot be undone.
+              undone. undone. undone. undone. undone.
+            </p>
+          </div>
+        </div>
+        <div className="text-center md:text-right mt-4 md:flex md:justify-end">
+          <button
+            type="button"
+            className="block w-full md:inline-block md:w-auto px-4 py-3 md:py-2 bg-red-200 text-red-700 rounded-lg font-semibold text-sm md:ml-2 md:order-2"
+          >
+            Delete Account
+          </button>
+          <button
+            type="button"
+            className="block w-full md:inline-block md:w-auto px-4 py-3 md:py-2 bg-gray-200 rounded-lg font-semibold text-sm mt-4
+          md:mt-0 md:order-1"
+            onClick={cancel}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AddStockModal;
+
+// reference
+/* https://tailwindcomponents.com/component/modal
+   https://codepen.io/iamsahilvhora/pen/LYYxQJw */

--- a/src/components/add-stock-modal/index.tsx
+++ b/src/components/add-stock-modal/index.tsx
@@ -50,8 +50,8 @@ const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
           </div>
         </div> */}
         <div className="px-2 py-5 sm:px-6 flex flex-col">
-          <h3 className="text-lg leading-6 font-medium text-gray-900">Applicant Information</h3>
-          <p className="mt-1 max-w-2xl text-sm text-gray-600">Personal details and application.</p>
+          <h3 className="text-lg leading-6 font-medium text-gray-900">Stock Information</h3>
+          {/* <p className="mt-1 max-w-2xl text-sm text-gray-600">Personal details and application.</p> */}
         </div>
         <div className="border-t border-gray-200">
           <dl>
@@ -71,7 +71,19 @@ const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
               </dd>
             </div>
             <div className="bg-white p-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 text-gray-600">
-              <dt className="text-sm font-medium text-gray-600">Quantity</dt>
+              <dt className="text-sm font-medium text-gray-600">Shares</dt>
+              <dd className="mt-1 text-sm sm:mt-0 sm:col-span-2 border border-gray-600 rounded-md">
+                <input
+                  type="text"
+                  name="first_name"
+                  id="first_name"
+                  autoComplete="given-name"
+                  className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                />
+              </dd>
+            </div>
+            <div className="bg-white p-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 text-gray-600">
+              <dt className="text-sm font-medium text-gray-600">Buy Price</dt>
               <dd className="mt-1 text-sm sm:mt-0 sm:col-span-2 border border-gray-600 rounded-md">
                 <input
                   type="text"
@@ -83,6 +95,16 @@ const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
               </dd>
             </div>
             <div className="bg-gray-50 py-2 px-6 text-gray-600">
+              <div className="flex w-full text-xs">
+                <div className="flex w-5/12">
+                  <div className="flex-1 pr-3 text-left font-semibold">Dividend</div>
+                  <div className="flex-1 px-3 text-right">0</div>
+                </div>
+                <div className="flex w-7/12">
+                  <div className="flex-1 px-3 text-left font-semibold">Cost Basis</div>
+                  <div className="flex-1 pl-3 text-right">0</div>
+                </div>
+              </div>
               <div className="flex w-full text-xs">
                 <div className="flex w-5/12">
                   <div className="flex-1 pr-3 text-left font-semibold">Open</div>
@@ -121,7 +143,7 @@ const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
             type="button"
             className="block w-full md:inline-block md:w-auto px-4 py-3 md:py-2 bg-red-200 text-red-700 rounded-lg font-semibold text-sm md:ml-2 md:order-2"
           >
-            Delete Account
+            Add Stock
           </button>
           <button
             type="button"

--- a/src/components/add-stock-modal/index.tsx
+++ b/src/components/add-stock-modal/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 import cn from "classnames";
 
 type AddStockModalProps = {
@@ -7,6 +7,22 @@ type AddStockModalProps = {
 };
 
 const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  useEffect(() => {
+    const delayDebounceFn = setTimeout(() => {
+      console.log(searchTerm);
+      // Send Axios request here
+    }, 3000);
+
+    return () => clearTimeout(delayDebounceFn);
+  }, [searchTerm]);
+
+  const handleKeyDown = e => {
+    if (e.keyCode === 13) {
+      console.log("call API");
+    }
+  };
+
   return (
     <div
       className={cn("fixed px-4 md:flex md:items-center md:justify-center z-10 inset-0", {
@@ -21,7 +37,7 @@ const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
         aria-hidden="true"
       />
       <div className="bg-white rounded-lg md:max-w-md md:mx-auto p-4 fixed inset-x-0 bottom-0 z-50 mb-4 mx-4 md:relative shadow-lg">
-        <div className="md:flex items-center">
+        {/* <div className="md:flex items-center">
           <div className="rounded-full border border-gray-300 flex items-center justify-center w-16 h-16 flex-shrink-0 mx-auto">
             <i className="bx bx-error text-3xl" />
           </div>
@@ -32,6 +48,73 @@ const AddStockModal: FC<AddStockModalProps> = ({ isShowing, cancel }) => {
               undone. undone. undone. undone. undone.
             </p>
           </div>
+        </div> */}
+        <div className="px-2 py-5 sm:px-6 flex flex-col">
+          <h3 className="text-lg leading-6 font-medium text-gray-900">Applicant Information</h3>
+          <p className="mt-1 max-w-2xl text-sm text-gray-600">Personal details and application.</p>
+        </div>
+        <div className="border-t border-gray-200">
+          <dl>
+            <div className="bg-gray-50 p-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+              <dt className="text-sm font-medium text-gray-600">Ticker</dt>
+              {/* <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">Margot Foster</dd> */}
+              <dd className="text-sm text-gray-900 sm:mt-0 sm:col-span-2 border  border-gray-600 rounded-md">
+                <input
+                  type="text"
+                  name="first_name"
+                  id="first_name"
+                  autoComplete="given-name"
+                  className="focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                  onChange={e => setSearchTerm(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                />
+              </dd>
+            </div>
+            <div className="bg-white p-2 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6 text-gray-600">
+              <dt className="text-sm font-medium text-gray-600">Quantity</dt>
+              <dd className="mt-1 text-sm sm:mt-0 sm:col-span-2 border border-gray-600 rounded-md">
+                <input
+                  type="text"
+                  name="first_name"
+                  id="first_name"
+                  autoComplete="given-name"
+                  className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md"
+                />
+              </dd>
+            </div>
+            <div className="bg-gray-50 py-2 px-6 text-gray-600">
+              <div className="flex w-full text-xs">
+                <div className="flex w-5/12">
+                  <div className="flex-1 pr-3 text-left font-semibold">Open</div>
+                  <div className="flex-1 px-3 text-right">0</div>
+                </div>
+                <div className="flex w-7/12">
+                  <div className="flex-1 px-3 text-left font-semibold">Market Cap</div>
+                  <div className="flex-1 pl-3 text-right">0</div>
+                </div>
+              </div>
+              <div className="flex w-full text-xs">
+                <div className="flex w-5/12">
+                  <div className="flex-1 pr-3 text-left font-semibold">High</div>
+                  <div className="px-3 text-right">0</div>
+                </div>
+                <div className="flex w-7/12">
+                  <div className="flex-1 px-3 text-left font-semibold">P/E ratio</div>
+                  <div className="pl-3 text-right">0</div>
+                </div>
+              </div>
+              <div className="flex w-full text-xs">
+                <div className="flex w-5/12">
+                  <div className="flex-1 pr-3 text-left font-semibold">Low</div>
+                  <div className="px-3 text-right">0</div>
+                </div>
+                <div className="flex w-7/12">
+                  <div className="flex-1 px-3 text-left font-semibold">Dividend yield</div>
+                  <div className="pl-3 text-right">0%</div>
+                </div>
+              </div>
+            </div>
+          </dl>
         </div>
         <div className="text-center md:text-right mt-4 md:flex md:justify-end">
           <button

--- a/src/components/portfolio-options/index.module.css
+++ b/src/components/portfolio-options/index.module.css
@@ -28,7 +28,5 @@
 
 
 .active, .icon:hover {
-  /* background-color: #404040; */
   @apply bg-charcoal-300;
-  background-color: #2b2b2b;
 }

--- a/src/components/portfolio-options/index.module.css
+++ b/src/components/portfolio-options/index.module.css
@@ -1,0 +1,34 @@
+.portfolioOptions {
+
+  @apply box-border border-r text-gray-500 h-screen;
+
+  max-width: max-content;
+  background-color: #151515;
+  border-color: #2b2b2b;
+  padding: 0.5em;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon {
+  @apply bg-charcoal-400 rounded-lg text-gray-500;
+  text-align: center;
+  cursor: pointer;
+  height: 3em;
+  width: 3em;
+  font-size: 1em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  /* margin-bottom: 8px; */
+}
+
+
+.active, .icon:hover {
+  /* background-color: #404040; */
+  @apply bg-charcoal-300;
+  background-color: #2b2b2b;
+}

--- a/src/components/portfolio-options/index.tsx
+++ b/src/components/portfolio-options/index.tsx
@@ -1,0 +1,64 @@
+import { FC } from "react";
+import cn from "classnames";
+import styles from "./index.module.css";
+
+type PortfolioOptionsProps = {
+  openAddStockModal: () => void;
+};
+
+const PortfolioOptions: FC<PortfolioOptionsProps> = ({ openAddStockModal }) => {
+  return (
+    <div className="bg-charcoal-900 px-4 h-full flex flex-row align-middle justify-between items-center rounded-lg">
+      <button type="button" className={styles.icon} onClick={openAddStockModal}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          className="w-8"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1"
+            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+          />
+        </svg>
+      </button>
+      <button type="button" className={styles.icon}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          className="w-8"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1"
+            d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"
+          />
+        </svg>
+      </button>
+      <button type="button" className={styles.icon}>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          className="w-8"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1"
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default PortfolioOptions;

--- a/src/components/portfolio-options/index.tsx
+++ b/src/components/portfolio-options/index.tsx
@@ -9,54 +9,78 @@ type PortfolioOptionsProps = {
 const PortfolioOptions: FC<PortfolioOptionsProps> = ({ openAddStockModal }) => {
   return (
     <div className="bg-charcoal-900 px-4 h-full flex flex-row align-middle justify-between items-center rounded-lg">
-      <button type="button" className={styles.icon} onClick={openAddStockModal}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          className="w-8"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1"
-            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-          />
-        </svg>
-      </button>
-      <button type="button" className={styles.icon}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          className="w-8"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1"
-            d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"
-          />
-        </svg>
-      </button>
-      <button type="button" className={styles.icon}>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          className="w-8"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1"
-            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
-          />
-        </svg>
-      </button>
+      <ul className="nav flex flex-row">
+        <button type="button" className={styles.icon} onClick={openAddStockModal}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            className="w-8"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1"
+              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+            />
+          </svg>
+        </button>
+      </ul>
+
+      <ul className="nav flex flex-row space-x-5">
+        <button type="button" className={styles.icon}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            className="w-8"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1"
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+        </button>
+        <button type="button" className={styles.icon}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            className="w-8"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1"
+              d="M17 14v6m-3-3h6M6 10h2a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2zm10 0h2a2 2 0 002-2V6a2 2 0 00-2-2h-2a2 2 0 00-2 2v2a2 2 0 002 2zM6 20h2a2 2 0 002-2v-2a2 2 0 00-2-2H6a2 2 0 00-2 2v2a2 2 0 002 2z"
+            />
+          </svg>
+        </button>
+      </ul>
+
+      <ul className="nav flex flex-row">
+        <button type="button" className={styles.icon}>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            className="w-8"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1"
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+            />
+          </svg>
+        </button>
+      </ul>
     </div>
   );
 };

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,13 @@
+import { useState } from "react";
+
+const useModal = (initialValue = false): { isShowing: boolean; toggle: () => void } => {
+  const [isShowing, setIsShowing] = useState(initialValue);
+  const toggle = () => setIsShowing(!isShowing);
+
+  return {
+    isShowing,
+    toggle
+  };
+};
+
+export default useModal;

--- a/src/pages/portfolio.tsx
+++ b/src/pages/portfolio.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import DataTable, { createTheme, defaultThemes } from "react-data-table-component";
 import AddStockModal from "../components/add-stock-modal";
+import PortfolioOptions from "../components/portfolio-options";
 import useModal from "../hooks/useModal";
 import DefaultLayout from "../layouts/default";
 
@@ -341,7 +342,7 @@ const Portfolio: FC = () => {
       >
         <AddStockModal isShowing={isShowing} cancel={toggle} />
         <div className="portfolio-primary-panel overflow-y-hidden">
-          <div className="h-20 bg-gray-800 flex flex-row">
+          <div className="h-20 flex flex-row">
             <div className="w-2/3 bg-red-100 h-full flex items-center p-4 justify-between">
               <div className="flex flex-col">
                 <span className="text-xs m-1 uppercase  text-gray-700">INVESTED AMOUNT</span>
@@ -367,27 +368,8 @@ const Portfolio: FC = () => {
                 </div>
               </div>
             </div>
-            <div className="w-1/3 bg-gray-200 h-full p-4 flex align-middle">
-              <button
-                type="button"
-                className="bg-red-500 hover:bg-red-400 focus:bg-red-600 focus:outline-none focus:shadow-none outline-none text-white p-2 rounded transform hover:scale-105 motion-reduce:transform-none"
-                onClick={toggle}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  className="w-8"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-                  />
-                </svg>
-              </button>
+            <div className="w-1/3">
+              <PortfolioOptions openAddStockModal={toggle} />
             </div>
           </div>
           <DataTable

--- a/src/pages/portfolio.tsx
+++ b/src/pages/portfolio.tsx
@@ -1,5 +1,7 @@
 import { FC } from "react";
 import DataTable, { createTheme, defaultThemes } from "react-data-table-component";
+import AddStockModal from "../components/add-stock-modal";
+import useModal from "../hooks/useModal";
 import DefaultLayout from "../layouts/default";
 
 createTheme("solarized", {
@@ -321,7 +323,6 @@ const customStyles2 = {
 };
 
 const TableAction = data => {
-  console.log(data);
   return (
     <div>
       <div style={{ fontWeight: 700 }}>Hello</div>
@@ -330,9 +331,7 @@ const TableAction = data => {
 };
 
 const Portfolio: FC = () => {
-  // <div className="px-10 py-12 lg:px-56 flex justify-center">
-  //   <Loading />
-  // </div>
+  const { isShowing, toggle } = useModal(false);
   return (
     <>
       <DefaultLayout
@@ -340,6 +339,7 @@ const Portfolio: FC = () => {
         sidebar="portfolio"
         description="You can see your portfolios estimated value & progress below"
       >
+        <AddStockModal isShowing={isShowing} cancel={toggle} />
         <div className="portfolio-primary-panel overflow-y-hidden">
           <div className="h-20 bg-gray-800 flex flex-row">
             <div className="w-2/3 bg-red-100 h-full flex items-center p-4 justify-between">
@@ -367,7 +367,28 @@ const Portfolio: FC = () => {
                 </div>
               </div>
             </div>
-            <div className="w-1/3 bg-red-500 h-full" />
+            <div className="w-1/3 bg-gray-200 h-full p-4 flex align-middle">
+              <button
+                type="button"
+                className="bg-red-500 hover:bg-red-400 focus:bg-red-600 focus:outline-none focus:shadow-none outline-none text-white p-2 rounded transform hover:scale-105 motion-reduce:transform-none"
+                onClick={toggle}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  className="w-8"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
           <DataTable
             title="Portfolio"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,12 +10,25 @@ module.exports = {
     "./src/pages/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
+    customForms: theme => ({
+      default: {
+        button: {
+          "&:focus": {
+            outline: "none",
+            boxShadow: "none",
+            borderColor: "none"
+          }
+        }
+      }
+    }),
     extend: {
       fontFamily: {
         sans: ["Inter", ...defaultTheme.fontFamily.sans]
       }
     }
   },
-  variants: {},
+  variants: {
+    backgroundColor: ["responsive", "hover", "focus", "active"]
+  },
   plugins: []
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,18 +10,14 @@ module.exports = {
     "./src/pages/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    customForms: theme => ({
-      default: {
-        button: {
-          "&:focus": {
-            outline: "none",
-            boxShadow: "none",
-            borderColor: "none"
-          }
-        }
-      }
-    }),
     extend: {
+      colors: {
+        charcoal: {
+          300: "#404040",
+          400: "#2b2b2b",
+          900: "#151515"
+        }
+      },
       fontFamily: {
         sans: ["Inter", ...defaultTheme.fontFamily.sans]
       }


### PR DESCRIPTION
* Add custom hook to show and hide the modal component.
* Add new component `add-stock-modal` to show the modal to input Stock Ticker.
* Add new component `portfolio-options`, the component is responsible for Options panel on the portfolio page, currently used to open the `add stock modal`.
* Add custom colors in tailwind.config.css

![image](https://user-images.githubusercontent.com/24829816/100924195-bb5f0600-34f9-11eb-8fd6-73b9720dedde.png)
![image](https://user-images.githubusercontent.com/24829816/100925768-e34f6900-34fb-11eb-8d1a-cbe49b1db4ad.png)
